### PR TITLE
It is better to use the repository field in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Ramon Moraes <mitternacht92.pub@gmail.com>"]
 description = "library to access nested structures using path-like string format."
 license = "MIT"
 documentation = "https://docs.rs/nestac/latest/nestac/"
-homepage = "https://github.com/mitternacht92/nestac"
+repository = "https://github.com/mitternacht92/nestac"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.